### PR TITLE
issue#9: Voorkom dubbele vaste lasten betalingen in de Cashflow

### DIFF
--- a/src/main/kotlin/io/vliet/plusmin/service/CashflowService.kt
+++ b/src/main/kotlin/io/vliet/plusmin/service/CashflowService.kt
@@ -92,7 +92,9 @@ class CashflowService {
                     else betaaldeInkomsten(betalingenInPeriode, date)
                 val uitgaven =
                     if (date > laatsteBetalingDatum.plusDays(1))
-                        continueBudgetUitgaven + budgetVasteLastenUitgaven(rekeningGroepen, date)
+                        continueBudgetUitgaven +
+                                budgetVasteLastenUitgaven(rekeningGroepen, date) -
+                                eerderBetaaldeVasteLastenUitgaven(betalingenInPeriode, date)
                     else if (date.equals(laatsteBetalingDatum.plusDays(1))) {
                         continueBudgetUitgaven +
                                 budgetVasteLastenUitgaven(rekeningGroepen, date) +
@@ -163,6 +165,13 @@ class CashflowService {
             .filter { it.budgetBetaalDag == date.dayOfMonth }
             .filter { it.maanden.isNullOrEmpty() || it.maanden!!.contains(date.monthValue) }
             .sumOf { it.budgetBedrag ?: BigDecimal.ZERO }
+    }
+
+    fun eerderBetaaldeVasteLastenUitgaven(betaaldeVasteLasten: List<Betaling>, date: LocalDate): BigDecimal {
+        return -betaaldeVasteLasten
+            .asSequence()
+            .filter { it.bestemming.budgetBetaalDag == date.dayOfMonth }
+            .sumOf { it.bedrag }
     }
 
     fun budgetAflossing(rekeningGroepen: List<RekeningGroep>, date: LocalDate): BigDecimal {


### PR DESCRIPTION
Als een vaste last al is betaal vóór de geplande betaaldatum, wordt in de cashflow (als de laatste betaling tussen de werkelijke en geplande datum is), de betaling 2x opgenomen: 1x op de werkelijke datum en 1x op de geplande datum.

De betaling moet dan niet meer op de geplande datum worden opgenomen.