### PR TITLE
fix/voorsprong weg uit achterstand van de cashflow

### DIFF
--- a/src/main/kotlin/io/vliet/plusmin/domain/Periode.kt
+++ b/src/main/kotlin/io/vliet/plusmin/domain/Periode.kt
@@ -60,6 +60,16 @@ class Periode(
     companion object {
         val openPeriodes = listOf(PeriodeStatus.HUIDIG, PeriodeStatus.OPEN)
         val geslotenPeriodes = listOf(PeriodeStatus.GESLOTEN, PeriodeStatus.OPGERUIMD)
+        fun berekenDagInPeriode(dagInMaand: Int, periode: Periode): LocalDate {
+            val jaar = periode.periodeStartDatum.year
+            val maand = periode.periodeStartDatum.monthValue
+            val periodeStartDag = periode.periodeStartDatum.dayOfMonth
+            return if (dagInMaand < periodeStartDag) {
+                LocalDate.of(jaar, maand, dagInMaand).plusMonths(1)
+            } else {
+                LocalDate.of(jaar, maand, dagInMaand)
+            }
+        }
     }
 
     enum class PeriodeStatus {

--- a/src/main/kotlin/io/vliet/plusmin/domain/Rekening.kt
+++ b/src/main/kotlin/io/vliet/plusmin/domain/Rekening.kt
@@ -195,7 +195,7 @@ class Rekening(
                 BigDecimal.ZERO
             else {
                 val budgetBetaalDagInPeriode = if (this.budgetBetaalDag != null)
-                    berekenDagInPeriode(this.budgetBetaalDag, periode) else null
+                    Periode.berekenDagInPeriode(this.budgetBetaalDag, periode) else null
                 val wordtBetalingVerwacht =
                     this.maanden.isNullOrEmpty() || this.maanden!!.contains(budgetBetaalDagInPeriode?.monthValue)
                 if (this.budgetPeriodiciteit == BudgetPeriodiciteit.WEEK) {
@@ -240,24 +240,6 @@ class Rekening(
         return (this.vanPeriode == null || periode.periodeStartDatum >= this.vanPeriode.periodeStartDatum) &&
                 (this.totEnMetPeriode == null || periode.periodeEindDatum <= this.totEnMetPeriode.periodeEindDatum) &&
                 (periode.periodeStartDatum != periode.periodeEindDatum)
-    }
-
-    fun rekeningVerwachtBetalingInPeriode(periode: Periode): Boolean {
-        if (this.budgetBetaalDag == null || this.maanden.isNullOrEmpty())
-            return true
-        val betaaldagInPeriode = berekenDagInPeriode(this.budgetBetaalDag, periode)
-        return this.maanden!!.contains(betaaldagInPeriode.monthValue)
-    }
-
-    fun berekenDagInPeriode(dagInMaand: Int, periode: Periode): LocalDate {
-        val jaar = periode.periodeStartDatum.year
-        val maand = periode.periodeStartDatum.monthValue
-        val periodeStartDag = periode.periodeStartDatum.dayOfMonth
-        return if (dagInMaand < periodeStartDag) {
-            LocalDate.of(jaar, maand, dagInMaand).plusMonths(1)
-        } else {
-            LocalDate.of(jaar, maand, dagInMaand)
-        }
     }
 
     fun isBedragBinnenVariabiliteit(

--- a/src/main/kotlin/io/vliet/plusmin/service/PeriodeService.kt
+++ b/src/main/kotlin/io/vliet/plusmin/service/PeriodeService.kt
@@ -40,17 +40,6 @@ class PeriodeService {
         return Pair(startDatum, startDatum.plusMonths(1).minusDays(1))
     }
 
-    fun berekenDagInPeriode(dagInMaand: Int, periode: Periode): LocalDate {
-        val jaar = periode.periodeStartDatum.year
-        val maand = periode.periodeStartDatum.monthValue
-        val periodeStartDag = periode.periodeStartDatum.dayOfMonth
-        return if (dagInMaand < periodeStartDag) {
-            LocalDate.of(jaar, maand, dagInMaand).plusMonths(1)
-        } else {
-            LocalDate.of(jaar, maand, dagInMaand)
-        }
-    }
-
     /*
         check of de huidige periode bestaat, anders aanmaken sinds de laatst bestaande periode
      */

--- a/src/main/kotlin/io/vliet/plusmin/service/StandInPeriodeService.kt
+++ b/src/main/kotlin/io/vliet/plusmin/service/StandInPeriodeService.kt
@@ -19,9 +19,6 @@ class StandInPeriodeService {
     lateinit var betalingRepository: BetalingRepository
 
     @Autowired
-    lateinit var periodeService: PeriodeService
-
-    @Autowired
     lateinit var periodeRepository: PeriodeRepository
 
     val logger: Logger = LoggerFactory.getLogger(this.javaClass.name)
@@ -133,7 +130,7 @@ class StandInPeriodeService {
             when (rekening.rekeningGroep.budgetType) {
                 RekeningGroep.BudgetType.VAST, RekeningGroep.BudgetType.INKOMSTEN -> {
                     val betaaldagInPeriode = if (rekening.budgetBetaalDag != null)
-                        periodeService.berekenDagInPeriode(rekening.budgetBetaalDag, peilPeriode)
+                        Periode.berekenDagInPeriode(rekening.budgetBetaalDag, peilPeriode)
                     else null
 
                     if (betaaldagInPeriode == null) {


### PR DESCRIPTION
In de cashflow wordt op dag na de de laatste betaaldag de achterstand van vaste lasten/aflossingen opgenomen (want die moeten nog worden betaald); er werd onterecht ook de 'voorsprong' (negatief, dus als inkomsten maar wel rood) opgenomen